### PR TITLE
Add phpstan - static code analysis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,8 @@
     "squizlabs/php_codesniffer": "^3.5"
   },
   "minimum-stability": "dev",
-  "prefer-stable": true
+  "prefer-stable": true,
+  "scripts" : {
+    "test": "./vendor/bin/grumphp run"
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
   "require-dev": {
     "phpro/grumphp": "^1.3",
     "omnipay/tests": "^3",
-    "squizlabs/php_codesniffer": "^3.5"
+    "squizlabs/php_codesniffer": "^3.5",
+    "phpstan/phpstan": "^0.12.81"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -11,3 +11,12 @@ grumphp:
       ignore_patterns:
         - tests/
       triggered_by: [ php ]
+    phpstan:
+      autoload_file: ~
+      configuration: ~
+      level: null
+      force_patterns: [ ]
+      ignore_patterns: [ ]
+      triggered_by: [ 'php' ]
+      memory_limit: "-1"
+      use_grumphp_paths: true

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -42,8 +42,8 @@ class Gateway extends AbstractGateway
     public function getDefaultParameters(): array
     {
         return [
-            ApiCredentialsTrait::$brandIdParameterKey => '',
-            ApiCredentialsTrait::$secretKeyParameterKey => ''
+            ApiCredentialsTrait::getBrandIdParameterKey() => '',
+            ApiCredentialsTrait::getSecretKeyParameterKey() => ''
         ];
     }
 

--- a/src/Traits/ApiCredentialsTrait.php
+++ b/src/Traits/ApiCredentialsTrait.php
@@ -11,12 +11,28 @@ trait ApiCredentialsTrait
     /**
      * @var string
      */
-    public static $brandIdParameterKey = 'brand_id';
+    private static $brandIdParameterKey = 'brand_id';
 
     /**
      * @var string
      */
-    public static $secretKeyParameterKey = 'secretKey';
+    private static $secretKeyParameterKey = 'secretKey';
+
+    /**
+     * @return string
+     */
+    public static function getBrandIdParameterKey(): string
+    {
+        return self::$brandIdParameterKey;
+    }
+
+    /**
+     * @return string
+     */
+    public static function getSecretKeyParameterKey(): string
+    {
+        return self::$secretKeyParameterKey;
+    }
 
     /**
      * @param string $brandId


### PR DESCRIPTION
This PR will:
1. Add phpstan - static code analysis
2. Fix phpstan error codes
3. Add new script to composer.json file - 'test'

BREAKING CHANGE: Visibility of properties `$brandIdParameterKey` and `$secretKeyParameterKey` of trait `ApiCredentialsTrait` changed from public to private